### PR TITLE
Preserve metadata on writes to existing blobs

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -460,6 +460,17 @@ func (az *AzStorage) ReadInBuffer(options internal.ReadInBufferOptions) (length 
 }
 
 func (az *AzStorage) WriteFile(options internal.WriteFileOptions) (int, error) {
+	if az.stConfig.preserveMetadata {
+		ok := true
+		attr, err := az.storage.GetAttr(options.Handle.Path)
+		if err != nil {
+			ok = false
+		}
+		if ok {
+			// Deep copy the Metadata map
+			options.Metadata = cloneMap(attr.Metadata)
+		}
+	}
 	err := az.storage.Write(options)
 	return len(options.Data), err
 }

--- a/component/azstorage/config.go
+++ b/component/azstorage/config.go
@@ -180,6 +180,7 @@ type AzStorageOptions struct {
 	DisableCompression      bool   `config:"disable-compression" yaml:"disable-compression"`
 	Telemetry               string `config:"telemetry" yaml:"telemetry"`
 	HonourACL               bool   `config:"honour-acl" yaml:"honour-acl"`
+	PreserveMetadata        bool   `config:"preserve-metadata" yaml:"preserve-metadata"`
 	CPKEnabled              bool   `config:"cpk-enabled" yaml:"cpk-enabled"`
 	CPKEncryptionKey        string `config:"cpk-encryption-key" yaml:"cpk-encryption-key"`
 	CPKEncryptionKeySha256  string `config:"cpk-encryption-key-sha256" yaml:"cpk-encryption-key-sha256"`
@@ -508,7 +509,7 @@ func ParseAndValidateConfig(az *AzStorage, opt AzStorageOptions) error {
 	log.Info("ParseAndValidateConfig : Retry Config: retry-count %d, max-timeout %d, backoff-time %d, max-delay %d",
 		az.stConfig.maxRetries, az.stConfig.maxTimeout, az.stConfig.backoffTime, az.stConfig.maxRetryDelay)
 
-	log.Info("ParseAndValidateConfig : Telemetry : %s, honour-ACL %v, disable-symlink %v", az.stConfig.telemetry, az.stConfig.honourACL, az.stConfig.disableSymlink)
+	log.Info("ParseAndValidateConfig : Telemetry : %s, honour-ACL %v, preserve-metadata %v, disable-symlink %v", az.stConfig.telemetry, az.stConfig.honourACL, az.stConfig.preserveMetadata, az.stConfig.disableSymlink)
 
 	return nil
 }
@@ -558,6 +559,12 @@ func ParseAndReadDynamicConfig(az *AzStorage, opt AzStorageOptions, reload bool)
 		az.stConfig.honourACL = opt.HonourACL
 	} else {
 		az.stConfig.honourACL = false
+	}
+
+	if config.IsSet(compName + ".preserve-metadata") {
+		az.stConfig.preserveMetadata = opt.PreserveMetadata
+	} else {
+		az.stConfig.preserveMetadata = false
 	}
 
 	if config.IsSet("attr_cache.no-symlinks") {

--- a/component/azstorage/connection.go
+++ b/component/azstorage/connection.go
@@ -77,9 +77,10 @@ type AzStorageConfig struct {
 	maxResultsForList  int32
 	disableCompression bool
 
-	telemetry      string
-	honourACL      bool
-	disableSymlink bool
+	telemetry        string
+	honourACL        bool
+	preserveMetadata bool
+	disableSymlink   bool
 
 	// CPK related config
 	cpkEnabled             bool

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -666,3 +666,14 @@ func removeLeadingSlashes(s string) string {
 	}
 	return s
 }
+
+func cloneMap(m map[string]string) map[string]string {
+	var newMap map[string]string
+	if m != nil {
+		newMap := make(map[string]string)
+		for k, v := range m {
+			newMap[k] = v
+		}
+	}
+	return newMap
+}


### PR DESCRIPTION
Whether we use DFS or Block blob storage, doing a write through FUSE will clear any set metadata on the blob.

This is undesirable because if a user has interacted with the blob through the Azure Portal, and applied a metadata key-value pair, and subsequently updates the file through a blobfuse2 mount, the applied metadata would be cleared.

This will provide a method to preserve the metadata by reading the blob attributes, extracting the metadata, and setting the write options on all azstorage package providers to use the metadata that exists on the blob, without changing it.