### PR TITLE
Support metadata attributes written by azcopy with the `--preserve-posix-properties` flag

### DIFF
--- a/component/azstorage/azstorage.go
+++ b/component/azstorage/azstorage.go
@@ -469,6 +469,7 @@ func (az *AzStorage) WriteFile(options internal.WriteFileOptions) (int, error) {
 		if ok {
 			// Deep copy the Metadata map
 			options.Metadata = cloneMap(attr.Metadata)
+			delete(options.Metadata, modtimeKey)
 		}
 	}
 	err := az.storage.Write(options)

--- a/component/azstorage/block_blob.go
+++ b/component/azstorage/block_blob.go
@@ -60,6 +60,8 @@ import (
 const (
 	folderKey           = "hdi_isfolder"
 	symlinkKey          = "is_symlink"
+	modtimeKey          = "modtime"
+	createtimeKey       = "linux_btime"
 	max_context_timeout = 5
 )
 

--- a/component/azstorage/utils.go
+++ b/component/azstorage/utils.go
@@ -46,6 +46,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -376,6 +377,18 @@ func parseMetadata(attr *internal.ObjAttr, metadata map[string]string) {
 		} else if strings.ToLower(k) == symlinkKey && v == "true" {
 			attr.Flags = internal.NewSymlinkBitMap()
 			attr.Mode = attr.Mode | os.ModeSymlink
+		} else if strings.ToLower(k) == modtimeKey && v != "" {
+			mTimeInt64, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				mTimeInt64 = int64(0)
+			}
+			attr.Mtime = time.Unix(0, mTimeInt64)
+		} else if strings.ToLower(k) == createtimeKey && v != "" {
+			bTimeInt64, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				bTimeInt64 = int64(0)
+			}
+			attr.Crtime = time.Unix(0, bTimeInt64)
 		}
 	}
 }


### PR DESCRIPTION
`azcopy` is a program from Microsoft that allows for the copying of data from on-premises Linux systems to Azure Storage Accounts.

When files are copied to an Azure Storage Account, the creation time of the blob is set to the upload start time, and the last modified time is also set to the upload finish time.

In certain cases, file times as recorded in the POSIX `stat` struct and the Linux extended `statx` struct are used by existing applications to drive their own logic decisions. In order to allow those applications to migrate non-latency sensitive data storage to Azure Storage Accounts, we can make use of `azcopy` and the `--preserve-posix-properties` flag, to store these attributes from standard file systems into blob metadata.

In order to be able to mount these blob containers and have those metadata fields drive the `statx` struct fields, we are reading the `btime` and `mtime` fields stored as metadata.

In such case where a file uploaded by this method is subsequently modified, the FUSE driver will need to have the `preserve-metadata` flag set to true, and we will then only remove the mtime metadata field upon write. This will, on subsequent reads, fall back to the standard Last Modified Time for the blob to populate the mtime in the `statx` struct.